### PR TITLE
Add capability for testing actions.

### DIFF
--- a/ros2_easy_test/env.py
+++ b/ros2_easy_test/env.py
@@ -398,21 +398,18 @@ class ROS2TestEnvironment(Node):
         """Returns the service client for the given service name."""
 
         with self._registered_actions_lock:
-            try:
-                return self._registered_actions[name]
-            except KeyError:
-                # Get the type of the action.
-                # This is a bit tricky but relieves the user from passing it explicitly
-                module = import_module(goal_class.__module__)
-                # We cut away the trailing "_Goal" from the type name, which has length 5
-                base_type_name = goal_class.__name__[:-5]
-                base_type_class: Type = getattr(module, base_type_name)
+            # Get the type of the action.
+            # This is a bit tricky but relieves the user from passing it explicitly
+            module = import_module(goal_class.__module__)
+            # We cut away the trailing "_Goal" from the type name, which has length 5
+            base_type_name = goal_class.__name__[:-5]
+            base_type_class: Type = getattr(module, base_type_name)
 
-                objects = _ActionObjects(
-                    client=ActionClient(self, base_type_class, name, callback_group=self._action_cb_group)
-                )
-                self._registered_actions[name] = objects
-                return objects
+            objects = _ActionObjects(
+                client=ActionClient(self, base_type_class, name, callback_group=self._action_cb_group)
+            )
+            self._registered_actions[name] = objects
+            return objects
 
     def send_action_goal_and_wait_for_response(
         self,
@@ -421,25 +418,23 @@ class ROS2TestEnvironment(Node):
         timeout_availability: Optional[float] = 1,
         timeout_send_goal: Optional[float] = 1,
         timeout_get_result: Optional[float] = 10,
-    ) -> Tuple[Optional[ClientGoalHandle], Optional[List[Any]], Optional[Any]]:
+    ) -> Tuple[Optional[ClientGoalHandle], List[Any], Optional[Any]]:
         """Sends the goal to the given action and returns the response, feedbacks and result.
         Send the goal request to the action server, return the goal handle, all the feedback responses and the
         final result.
 
         Args:
-            name (str): The name of the action
-            goal_msg (Any): Goal message to send to the action server.
-            timeout_availability (Optional[float]): The timeout to wait for the service to be available.
-                                                    Defaults to 1.
-            timeout_send_goal (Optional[float]): _description_. Defaults to 1.
-            timeout_get_result (Optional[float]): _description_. Defaults to 10.
+            name: The name of the action
+            goal_msg: Goal message to send to the action server.
+            timeout_availability: The timeout to wait for the service to be available. Defaults to 1.
+            timeout_send_goal: Timeout in seconds for send goal. Defaults to 1.
+            timeout_get_result: Timeout in seconds for get result. Defaults to 10.
 
         Raises:
             TimeoutError: If the action server does not respond within the specified timeouts.
 
         Returns:
-            Tuple[Optional[ClientGoalHandle], Optional[List[Any]], Optional[Any]]: Return the goal handle for
-            the request, feedback responses and the goal result.
+            Return the goal handle for the request, feedback responses and the goal result.
         """
         action_objects = self._get_action_objects(name, type(goal_msg))
 

--- a/tests/example_nodes/minimal_action_server_with_context.py
+++ b/tests/example_nodes/minimal_action_server_with_context.py
@@ -64,6 +64,9 @@ class MinimalActionServerWithContext(Node):
         feedback_msg = Fibonacci.Feedback()
         feedback_msg.sequence = [0, 1]
 
+        # Helps avoid race condition in testing.
+        time.sleep(.1)
+
         # Start executing the action
         for i in range(1, goal_handle.request.order):
             if goal_handle.is_cancel_requested:
@@ -80,7 +83,7 @@ class MinimalActionServerWithContext(Node):
             goal_handle.publish_feedback(feedback_msg)
 
             # Sleep for demonstration purposes
-            time.sleep(.001)
+            time.sleep(.01)
 
         goal_handle.succeed()
 

--- a/tests/example_nodes/minimal_action_server_with_context.py
+++ b/tests/example_nodes/minimal_action_server_with_context.py
@@ -1,0 +1,111 @@
+# Modified from original example in examples_rclpy_minimal_action_server.server as follows:
+#       1. pass *args, **kwargs to __init__ and super().__init__.
+#       2. Reduce sleep times.
+#
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+
+from example_interfaces.action import Fibonacci
+
+import rclpy
+from rclpy.action import ActionServer, CancelResponse, GoalResponse
+from rclpy.callback_groups import ReentrantCallbackGroup
+from rclpy.executors import MultiThreadedExecutor
+from rclpy.node import Node
+
+
+class MinimalActionServerWithContext(Node):
+    def __init__(self, *args, **kwargs):
+        super().__init__("minimal_action_server", *args, **kwargs)
+
+        self._action_server = ActionServer(
+            self,
+            Fibonacci,
+            "fibonacci",
+            execute_callback=self.execute_callback,
+            callback_group=ReentrantCallbackGroup(),
+            goal_callback=self.goal_callback,
+            cancel_callback=self.cancel_callback,
+        )
+
+    def destroy(self):
+        self._action_server.destroy()
+        super().destroy_node()
+
+    def goal_callback(self, goal_request):
+        """Accept or reject a client request to begin an action."""
+        # This server allows multiple goals in parallel
+        self.get_logger().info("Received goal request")
+        return GoalResponse.ACCEPT
+
+    def cancel_callback(self, goal_handle):
+        """Accept or reject a client request to cancel an action."""
+        self.get_logger().info("Received cancel request")
+        return CancelResponse.ACCEPT
+
+    async def execute_callback(self, goal_handle):
+        """Execute a goal."""
+        self.get_logger().info("Executing goal...")
+
+        # Append the seeds for the Fibonacci sequence
+        feedback_msg = Fibonacci.Feedback()
+        feedback_msg.sequence = [0, 1]
+
+        # Start executing the action
+        for i in range(1, goal_handle.request.order):
+            if goal_handle.is_cancel_requested:
+                goal_handle.canceled()
+                self.get_logger().info("Goal canceled")
+                return Fibonacci.Result()
+
+            # Update Fibonacci sequence
+            feedback_msg.sequence.append(feedback_msg.sequence[i] + feedback_msg.sequence[i - 1])
+
+            self.get_logger().info("Publishing feedback: {0}".format(feedback_msg.sequence))
+
+            # Publish the feedback
+            goal_handle.publish_feedback(feedback_msg)
+
+            # Sleep for demonstration purposes
+            time.sleep(.001)
+
+        goal_handle.succeed()
+
+        # Populate result message
+        result = Fibonacci.Result()
+        result.sequence = feedback_msg.sequence
+
+        self.get_logger().info("Returning result: {0}".format(result.sequence))
+
+        return result
+
+
+def main(args=None):
+    rclpy.init(args=args)
+
+    minimal_action_server = MinimalActionServerWithContext()
+
+    # Use a MultiThreadedExecutor to enable processing goals concurrently
+    executor = MultiThreadedExecutor()
+
+    rclpy.spin(minimal_action_server, executor=executor)
+
+    minimal_action_server.destroy()
+    rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,4 +1,4 @@
-"""Tests the base functionality of the library."""
+"""Tests that actions can be checked correctly."""
 
 
 from action_msgs.msg import GoalStatus
@@ -17,10 +17,8 @@ def test_fibonacci_action(env: ROS2TestEnvironment) -> None:
     """Test action."""
 
     goal_handle, feedbacks, result_response = env.send_action_goal_and_wait_for_response(
-        name="fibonacci", action_type=Fibonacci, goal_msg=Fibonacci.Goal(order=4)
+        name="fibonacci", goal_msg=Fibonacci.Goal(order=4)
     )
-    print(f"{type(goal_handle)=}")
-
     assert isinstance(goal_handle, ClientGoalHandle)
     assert goal_handle.accepted is True
     assert goal_handle.status == GoalStatus.STATUS_SUCCEEDED

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -16,7 +16,7 @@ from .example_nodes.minimal_action_server_with_context import MinimalActionServe
 def test_fibonacci_action(env: ROS2TestEnvironment) -> None:
     """Test action."""
 
-    goal_handle, feedbacks, result_response = env.send_action_goal_and_wait_for_response(
+    goal_handle, feedbacks, result_response = env.send_action_goal_and_wait_for_result(
         name="fibonacci", goal_msg=Fibonacci.Goal(order=4)
     )
     assert isinstance(goal_handle, ClientGoalHandle)

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,0 +1,37 @@
+"""Tests the base functionality of the library."""
+
+
+from action_msgs.msg import GoalStatus
+from example_interfaces.action import Fibonacci
+from rclpy.action.client import ClientGoalHandle
+
+# What we are testing
+from ros2_easy_test import ROS2TestEnvironment, with_single_node
+
+# Module under test and interfaces
+from .example_nodes.minimal_action_server_with_context import MinimalActionServerWithContext
+
+
+@with_single_node(MinimalActionServerWithContext)
+def test_fibonacci_action(env: ROS2TestEnvironment) -> None:
+    """Test action."""
+
+    goal_handle, feedbacks, result_response = env.send_action_goal_and_wait_for_response(
+        name="fibonacci", action_type=Fibonacci, goal_msg=Fibonacci.Goal(order=4)
+    )
+    print(f"{type(goal_handle)=}")
+
+    assert isinstance(goal_handle, ClientGoalHandle)
+    assert goal_handle.accepted is True
+    assert goal_handle.status == GoalStatus.STATUS_SUCCEEDED
+
+    assert isinstance(feedbacks, list)
+    assert len(feedbacks) == 3
+    assert feedbacks == [
+        Fibonacci.Feedback(sequence=[0, 1, 1]),
+        Fibonacci.Feedback(sequence=[0, 1, 1, 2]),
+        Fibonacci.Feedback(sequence=[0, 1, 1, 2, 3]),
+    ]
+
+    assert result_response.status == GoalStatus.STATUS_SUCCEEDED
+    assert result_response.result == Fibonacci.Result(sequence=[0, 1, 1, 2, 3])


### PR DESCRIPTION
Per discussion in #25 this PR adds the capability to test actions with a single call like:
```python
    goal_handle, feedbacks, result_response = env.send_action_goal_and_wait_for_response(
        name="fibonacci",
        action_type=Fibonacci,
        goal_msg=Fibonacci.Goal(order=4),
    )
```
I couldn't figure out how to improve typing hints, so have a bunch of `Any` types.
Also I couldn't figure out how to auto-infer action type similar to _get_service_client, could use help with that.
