### PR TITLE
Allow configuring custom QoS Profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ def test_simple_publisher(env: ROS2TestEnvironment) -> None:
     response: String = env.assert_message_published("/chatter", timeout=5)
     assert response.data == "Hello World: 0"
 ```
+It is also possible to specify custom QoSProfiles for the `ROS2TestEnvironment` to use when subscribing or publishing on the specified topics. See [`tests/demo/latching_topic_test.py`](tests/demo/latching_topic_test.py) for an example. If no profile is specified, the default `QoSProfile(history=QoSHistoryPolicy.KEEP_ALL)` is used.
 
 You can optionally provide more parameters to the test setting, i.e., additionally pass `parameters={"some.thing": 30.2}` to the decorator.
 The argument of the test function receiving the `ROS2TestEnvironment` *must* be named `env`.

--- a/ros2_easy_test/env.py
+++ b/ros2_easy_test/env.py
@@ -54,8 +54,9 @@ class ROS2TestEnvironment(Node):
     Args:
         watch_topics: The topics (and their type) to watch for incoming messages.
             You may pass ``None`` to not watch any topic.
-        qos_profile: The topics and their qos profile to subscribe to or publish on.
+        qos_profile: The topics and their QoS profile to subscribe to or publish on.
             You may pass ``None`` to use the default profile.
+            All topics without an explicit profile use ``QoSProfile(history=QoSHistoryPolicy.KEEP_ALL)``.
     """
 
     def __init__(

--- a/tests/demo/latching_topic_test.py
+++ b/tests/demo/latching_topic_test.py
@@ -1,0 +1,22 @@
+# QoS Profile
+from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile
+
+# ROS2 interfaces
+from std_msgs.msg import String
+
+# Testing
+from ros2_easy_test import ROS2TestEnvironment, with_single_node
+
+# Module under test and interfaces
+from ..example_nodes.well_behaved import LatchingNode
+
+
+@with_single_node(
+    LatchingNode,
+    watch_topics={"/hello": String},
+    qos_profiles={
+        "/hello": QoSProfile(durability=DurabilityPolicy.TRANSIENT_LOCAL, history=HistoryPolicy.KEEP_ALL)
+    },
+)
+def test_plain_method(env: ROS2TestEnvironment) -> None:
+    env.assert_message_published("/hello")

--- a/tests/example_nodes/well_behaved.py
+++ b/tests/example_nodes/well_behaved.py
@@ -1,6 +1,6 @@
 from example_interfaces.srv import AddTwoInts
 from rclpy.node import Node
-from rclpy.qos import QoSHistoryPolicy, QoSProfile
+from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSHistoryPolicy, QoSProfile
 from std_msgs.msg import String
 
 
@@ -30,6 +30,14 @@ class EchoNode(Node):
         mouth = self.create_publisher(String, "/mouth", qos_profile)
         # Immediately forwards it and also holds a reference to the publisher:
         self.create_subscription(String, "/ear", mouth.publish, qos_profile)
+
+
+class LatchingNode(Node):
+    def __init__(self, *args, **kwargs):
+        super().__init__("latching_publisher", *args, **kwargs)
+
+        qos_profile = QoSProfile(durability=DurabilityPolicy.TRANSIENT_LOCAL, history=HistoryPolicy.KEEP_ALL)
+        self.create_publisher(String, "/hello", qos_profile).publish(String(data="Hello World"))
 
 
 class AddTwoIntsServer(Node):


### PR DESCRIPTION
My attempt to fix #31 

I made the QoS Profile configurable in the same way, watch_topics is configurable. The setting can be ommitted in which case the default profile as bevore is used.

I wasn't sure whether to use the passed profile for both publishers and subscribers. Another way would be to also add qos_profile as a parameter to the `env`'s `publish` method. The caller would have to ensure though, that the qos_profile doesn't change for subsuquent calls.
If you think that's a good Idea, I can also add it.

I can also add some explanation to the README and a test for the publish functionality if required.