### PR TITLE
Repair automated documentation building

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,7 @@
       "extensions": [
         "ms-python.python",
         "redhat.vscode-yaml",
-        "bungcip.better-toml",
+        "tamasfe.even-better-toml",
         "trond-snekvik.simple-rst",
         "GitHub.vscode-github-actions",
         "charliermarsh.ruff"

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Please read it before suggesting major features or changes.
 ## Contributing
 
 Basic installation is easiest with the provided `Dockerfile`.
-For the last piece of setup, either open it in the provided [Devcontainer](https://code.visualstudio.com/docs/remote/containers) or maunally run `rosdep install --from-paths ros2_easy_test && colcon build --symlink-install && pip install -e './ros2_easy_test[dev]` afterward.
+For the last piece of setup, either open it in the provided [Devcontainer](https://code.visualstudio.com/docs/remote/containers) or maunally run `rosdep install --from-paths ros2_easy_test && colcon build --symlink-install && pip install -e './ros2_easy_test[dev]'` afterward.
 
 After this, you will have access to the configured formatter (`ruff format`) and linter (`ruff check`).
 
@@ -127,7 +127,7 @@ You can run the test with simply `pytest`. Coverage reports and timings will be 
 Building the documentation is simple, too:
 ```shell
 # Install the required dependencies
-pip install -e ".[doc]"
+pip install -e 'ros2_easy_test[doc]'
 
 # Build the documentation
 cd doc

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -9,23 +9,32 @@
 import re
 import sys
 from pathlib import Path
-from unittest.mock import Mock
 
 # -- Mock ROS2 ---------------------------------------------------------------
 
 try:
     import rclpy
 except ImportError:
-    sys.modules["rclpy"] = Mock()
+    from unittest.mock import NonCallableMock
+
+    for module in [
+        "rclpy",
+        "rclpy.action",
+        "rclpy.action.client",
+        "rclpy.callback_groups",
+        "rclpy.client",
+        "rclpy.context",
+        "rclpy.executors",
+        "rclpy.node",
+        "rclpy.parameter",
+        "rclpy.publisher",
+        "rclpy.qos",
+        "rclpy.task",
+        "action_msgs.msg",
+    ]:
+        sys.modules[module] = NonCallableMock()
 else:
     del rclpy
-
-try:
-    import action_msgs
-except ImportError:
-    sys.modules["action_msgs"] = Mock()
-else:
-    del action_msgs
 
 # -- Project information -----------------------------------------------------
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -33,6 +33,13 @@ except ImportError:
         "action_msgs.msg",
     ]:
         sys.modules[module] = NonCallableMock()
+
+    # This is needed for the autodoc to work (when inheriting from rclpy.node.Node)
+    class Node:
+        """Mocked Node class."""
+
+    sys.modules["rclpy.node"].Node = Node
+
 else:
     del rclpy
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -7,7 +7,25 @@
 # -- Setup -------------------------------------------------------------------
 
 import re
+import sys
 from pathlib import Path
+from unittest.mock import Mock
+
+# -- Mock ROS2 ---------------------------------------------------------------
+
+try:
+    import rclpy
+except ImportError:
+    sys.modules["rclpy"] = Mock()
+else:
+    del rclpy
+
+try:
+    import action_msgs
+except ImportError:
+    sys.modules["action_msgs"] = Mock()
+else:
+    del action_msgs
 
 # -- Project information -----------------------------------------------------
 


### PR DESCRIPTION
Closes  #46

It previously failed because no proper ROS2 installation was present on readthedocs.

It also fixes some minor issues.